### PR TITLE
Add keybase, kitty, postman, and slack icons

### DIFF
--- a/autoname_workspaces.py
+++ b/autoname_workspaces.py
@@ -55,9 +55,13 @@ WINDOW_ICONS = {
     'firefox': fa.icons['firefox'],
     'google-chrome': fa.icons['chrome'],
     'gpick': fa.icons['eyedropper'],
+    'keybase': fa.icons['key'],
     'kicad': fa.icons['microchip'],
+    'kitty': fa.icons['terminal'],
     'libreoffice': fa.icons['file-text-o'],
     'mupdf': fa.icons['file-pdf-o'],
+    'postman': fa.icons['space-shuttle'],
+    'slack': fa.icons['slack'],
     'spotify': fa.icons['music'],  # could also use the 'spotify' icon
     'steam': fa.icons['steam'],
     'subl': fa.icons['file-text-o'],


### PR DESCRIPTION
Hi, again!

I have added new icons for keybase (key management service), kitty (a terminal emulator), postman (API exploration tool), and slack (a chat client). Here they are for upstream use, if you want them.

PS: Thanks for the great tool, it really makes the tabs really readable! :tada: 