### PR TITLE
Add option to format the list of icons.

### DIFF
--- a/util.py
+++ b/util.py
@@ -3,7 +3,7 @@
 import re
 import logging
 import subprocess as proc
-from collections import namedtuple
+from collections import namedtuple, Counter
 
 # A type that represents a parsed workspace "name".
 NameParts = namedtuple('NameParts', ['num', 'shortname', 'icons'])
@@ -51,3 +51,53 @@ def xprop(win_id, property):
     except proc.CalledProcessError as e:
         logging.warn("Unable to get property for window '%d'" % win_id)
         return None
+
+
+# Unicode subscript and superscript numbers
+_superscript = "⁰¹²³⁴⁵⁶⁷⁸⁹"
+_subscript = "₀₁₂₃₄₅₆₇₈₉"
+
+def _encode_base_10_number(n: int, symbols: str) -> str:
+    """Write a number in base 10 using symbols from a given string.
+
+    Examples:
+    >>> _encode_base_10_number(42, "0123456789")
+    "42"
+    >>> _encode_base_10_number(42, "abcdefghij")
+    "eb"
+    >>> _encode_base_10_number(42, "₀₁₂₃₄₅₆₇₈₉")
+    "₄₂"
+    """
+    return ''.join([symbols[int(digit)] for digit in str(n)])
+
+
+def format_icon_list(icon_list, icon_list_format='default'):
+    if icon_list_format.lower() == 'default':
+        # Default (no formatting)
+        return ' '.join(icon_list)
+
+    elif icon_list_format.lower() == 'mathematician':
+        # Mathematician mode
+        # aababa -> a⁴b²
+        new_list = []
+        for icon, count in Counter(icon_list).items():
+            if count > 1:
+                new_list.append(icon + _encode_base_10_number(count, _superscript))
+            else:
+                new_list.append(icon)
+        return ' '.join(new_list)
+
+    elif icon_list_format.lower() == 'chemist':
+        # Chemist mode
+        # aababa -> a₄b₂
+        new_list = []
+        for icon, count in Counter(icon_list).items():
+            if count > 1:
+                new_list.append(icon + _encode_base_10_number(count, _subscript))
+            else:
+                new_list.append(icon)
+        return ' '.join(new_list)
+
+    else:
+        raise ValueError("Unknown format name for the list of icons: ", icon_list_format)
+


### PR DESCRIPTION
Hi @justbuchanan,

First, thank you for sharing your scripts. I've been using the workspace auto-renaming function in the last weeks and I like it a lot.

Here is a small feature I added for my own use, feel free to merge it (or not) in your repository.

The point is to group together identical icons to have, for instance, A²B instead of AAB.
This is controlled by a command-line option `--icon_list_format`.

Cheers,
