### PR TITLE
make compatible with i3ipc>=2.0

### DIFF
--- a/new_workspace.py
+++ b/new_workspace.py
@@ -15,9 +15,9 @@ def find_next_ws_num_on_monitor(i3):
     focused_monitor = focused_workspace(i3).output
     logging.info('focused monitor: %s' % focused_monitor)
 
-    ws_on_monitor = filter(lambda ws: ws['output'] == focused_monitor,
+    ws_on_monitor = filter(lambda ws: ws.output == focused_monitor,
                            i3.get_workspaces())
-    nums = [ws['num'] for ws in ws_on_monitor]
+    nums = [ws.num for ws in ws_on_monitor]
     maxnum = max(nums)
     logging.info('max workspace on monitor: %s' % str(maxnum))
 


### PR DESCRIPTION
The output and num attributes of `WorkspaceReply` are not subscriptable anymore in `i3ipc>=2`.