### PR TITLE
util.py: fix SyntaxWarning in Python 3.12

### DIFF
--- a/util.py
+++ b/util.py
@@ -19,7 +19,7 @@ def focused_workspace(i3):
 # * 'icons' - the string that comes after the
 # Any field that's missing will be None in the returned dict
 def parse_workspace_name(name):
-    m = re.match('(?P<num>\d+):?(?P<shortname>\w+)? ?(?P<icons>.+)?',
+    m = re.match(r'(?P<num>\d+):?(?P<shortname>\w+)? ?(?P<icons>.+)?',
                  name).groupdict()
     return NameParts(**m)
 


### PR DESCRIPTION
Python 3.12 (which is shipped on Ubuntu 24.04) raises a SyntaxWarning for a backslash-character pair (it was previously a DeprecationWarning, which is hidden by default). Fix it by using a raw string as suggested in the Python 3.12 release notes[1].

[1]: https://docs.python.org/3/whatsnew/3.12.html#other-language-changes